### PR TITLE
ログインエラー時のメッセージを翻訳する

### DIFF
--- a/apps/app/public/static/locales/en_US/translation.json
+++ b/apps/app/public/static/locales/en_US/translation.json
@@ -761,7 +761,9 @@
     "registration_successful": "Registration successful. Please wait for administrator approval.",
     "Setup": "Setup",
     "enabled_ldap_has_configuration_problem": "LDAP is enabled but the configuration has something wrong.",
-    "set_env_var_for_logs": "(Please set the environment variables <code>DEBUG=crowi:service:PassportService</code> to get the logs)"
+    "set_env_var_for_logs": "(Please set the environment variables <code>DEBUG=crowi:service:PassportService</code> to get the logs)",
+    "wait_approve": "Wait for approved by administrators.",
+    "account_suspended": "This account is suspended."
   },
   "invited": {
     "title": "Invited",

--- a/apps/app/public/static/locales/fr_FR/translation.json
+++ b/apps/app/public/static/locales/fr_FR/translation.json
@@ -755,7 +755,9 @@
     "registration_successful": "Inscription réussie. Demander l'approbation d'un administrateur.",
     "Setup": "Configuration",
     "enabled_ldap_has_configuration_problem": "LDAP actif, vérifier la configuration.",
-    "set_env_var_for_logs": "(Remplir les variables d'environnement <code>DEBUG=crowi:service:PassportService</code> pour obtenir les journaux d'erreur)"
+    "set_env_var_for_logs": "(Remplir les variables d'environnement <code>DEBUG=crowi:service:PassportService</code> pour obtenir les journaux d'erreur)",
+    "wait_approve": "Veuillez attendre l'approbation de l'administrateur.",
+    "account_suspended": "Ce compte est suspendu."
   },
   "invited": {
     "title": "Invité",

--- a/apps/app/public/static/locales/ja_JP/translation.json
+++ b/apps/app/public/static/locales/ja_JP/translation.json
@@ -793,7 +793,9 @@
     "registration_successful": "登録が完了しました。管理者の承認をお待ちください。",
     "Setup": "セットアップ",
     "enabled_ldap_has_configuration_problem": "LDAPは有効ですが、設定に問題があります。",
-    "set_env_var_for_logs": "(ログを取得するためには、環境変数 <code>DEBUG=crowi:service:PassportService</code> を設定してください。)"
+    "set_env_var_for_logs": "(ログを取得するためには、環境変数 <code>DEBUG=crowi:service:PassportService</code> を設定してください。)",
+    "wait_approve": "管理者の承認をお待ちください。",
+    "account_suspended": "このアカウントは停止されています。"
   },
   "invited": {
     "title": "招待",

--- a/apps/app/public/static/locales/zh_CN/translation.json
+++ b/apps/app/public/static/locales/zh_CN/translation.json
@@ -764,7 +764,9 @@
     "registration_successful": "注册成功。请等待管理员批准",
     "Setup": "安装程序",
     "enabled_ldap_has_configuration_problem": "启用了LDAP，但配置有问题。",
-    "set_env_var_for_logs": "(请设置环境变量 <code>DEBUG=crowi:service:PassportService</code> 以获得日志。)"
+    "set_env_var_for_logs": "(请设置环境变量 <code>DEBUG=crowi:service:PassportService</code> 以获得日志。)",
+    "wait_approve": "请等待管理员批准。",
+    "account_suspended": "该帐户已被暂停。"
   },
   "invited": {
     "invited": "邀请函",

--- a/apps/app/src/pages/login/error/[message].page.tsx
+++ b/apps/app/src/pages/login/error/[message].page.tsx
@@ -30,7 +30,7 @@ const LoginPage: NextPage<CommonProps> = () => {
         <div className="alert alert-warning">
           <h2>{ t('login.sign_in_error') }</h2>
         </div>
-        <p>Wait for approved by administrators.</p>
+        <p>{ t('login.wait_approve') }</p>
       </>
     );
   };
@@ -41,7 +41,7 @@ const LoginPage: NextPage<CommonProps> = () => {
         <div className="alert alert-warning">
           <h2>{ t('login.sign_in_error') }</h2>
         </div>
-        <p>This account is suspended.</p>
+        <p>{ t('login.account_suspended') }</p>
       </>
     );
   };


### PR DESCRIPTION
> [!WARNING]
> now pending...

1. 変更自体はこれで正しいものの、上流に Pull Request を送るほどの内容でもない気がする。
2. 上流にマージしないということは、すなわち我々独自のビルド＆デプロイパイプラインの構築が必要。ちょっと今はその体力がないのと、運用を楽にするために別の運用が大変になりそうで、今ひとつ踏み切れない。
3. 一方で、今後も上流の変更は積極的に取り入れていきたい。

以上を考慮し、一旦保留にします。

逆に言うと、2の構築をうまくできればこちらの master へ本 PR をマージしても良いと思います。

# 補足

- 英語は変更前の本文をコピペ。
- 日本語は樋川が翻訳。
- フランス語、中国語は Google 翻訳頼み。
